### PR TITLE
lcms2 2.16: with  libtiff 4.5.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
   - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/dcd043c
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/dcd043c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
   - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc

--- a/recipe/0003_fix_a_bug_in_planar_half16_formatter.patch
+++ b/recipe/0003_fix_a_bug_in_planar_half16_formatter.patch
@@ -1,0 +1,33 @@
+From e88056ef81e42cd1fe06945da9d44ac95c80fa48 Mon Sep 17 00:00:00 2001
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Tue, 12 Dec 2023 19:59:09 +0100
+Subject: [PATCH] Fix a bug in planar half16 formatter
+
+Thanks to @cgohlke for finding it
+---
+ src/cmspack.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/cmspack.c b/src/cmspack.c
+index ac93bcd8..5ebbd208 100644
+--- a/src/cmspack.c
++++ b/src/cmspack.c
+@@ -1078,8 +1078,7 @@ cmsINLINE cmsBool IsInkSpace(cmsUInt32Number Type)
+ }
+ 
+ // Return the size in bytes of a given formatter
+-static
+-cmsUInt32Number PixelSize(cmsUInt32Number Format)
++cmsINLINE cmsUInt32Number PixelSize(cmsUInt32Number Format)
+ {
+     cmsUInt32Number fmt_bytes = T_BYTES(Format);
+ 
+@@ -3426,7 +3425,7 @@ cmsUInt8Number* UnrollHalfToFloat(_cmsTRANSFORM* info,
+     cmsUInt32Number i, start = 0;
+     cmsFloat32Number maximum = IsInkSpace(info ->InputFormat) ? 100.0F : 1.0F;
+ 
+-    Stride /= PixelSize(info->OutputFormat);
++    Stride /= PixelSize(info->InputFormat);
+ 
+     if (ExtraFirst)
+             start = Extra;

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,11 @@
 set UseEnv=true
 
-if "%ARCH%" == "32" (
-    set PLATFORM=Win32
-) else (
-    set PLATFORM=x64
-)
-
 msbuild ^
-  /p:Platform=%PLATFORM% ^
+  /p:Platform=x64 ^
   /p:Configuration=Release ^
   /p:AdditionalIncludeDirectories=%LIBRARY_INC% ^
   /p:AdditionalDependencies=/LIBPATH:%LIBRARY_LIB% ^
-  Projects\VC2017\lcms2.sln
+  Projects\VC2019\lcms2.sln
 if errorlevel 1 exit 1
 
 REM For debugging Purposes, you may want to list the files in the 3 important directories

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,14 @@
 # Get an updated config.sub and config.guess
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* .
 
-./configure --prefix=$PREFIX --with-tiff=$PREFIX --with-jpeg=$PREFIX
+./configure \
+	--prefix=$PREFIX \
+	--disable-static \
+	--with-tiff=$PREFIX \
+	--with-jpeg=$PREFIX
+
 make -j${CPU_COUNT}
-make check
+
 make install
+
+make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,7 @@ requirements:
     - m2-patch  # [win]
   host:
     - jpeg {{ jpeg }}
-    # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
-    - libtiff 4.5.1          # [win]
-    - libtiff {{ libtiff }}  # [not win]
+    - libtiff {{ libtiff }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     - 0001_windows_linux_compat.patch          # [win]
     - 0002_change_windows_sdk_version.patch    # [win]
+    - 0003_fix_a_bug_in_planar_half16_formatter.patch
 
 build:
   number: 0
@@ -24,6 +25,7 @@ requirements:
     - make      # [not win]
     - libtool   # [unix]
     - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - jpeg {{ jpeg }}
     - libtiff {{ libtiff }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - libtool  # [unix]
   host:
     - jpeg {{ jpeg }}
-    - libtiff 4.5.1
+    - libtiff {{ libtiff }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,9 @@ requirements:
     - libtool  # [unix]
   host:
     - jpeg {{ jpeg }}
-    - libtiff {{ libtiff }}
+    # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
+    - libtiff 4.5.1          # [win]
+    - libtiff {{ libtiff }}  # [not win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "lcms2" %}
-{% set version = "2.12" %}
+{% set version = "2.16" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/mm2/Little-CMS/archive/{{ version }}.tar.gz
-  sha256: e501f1482fc424550ef3abbf86bf1c66090e1661249e89552d39ed5bf935df66
+  url: https://github.com/mm2/Little-CMS/releases/download/lcms{{ version }}/lcms2-{{ version }}.tar.gz
+  sha256: d873d34ad8b9b4cea010631f1a6228d2087475e4dc5e763eb81acc23d9d45a51
   patches:
     - 0001_windows_linux_compat.patch          # [win]
     - 0002_change_windows_sdk_version.patch    # [win]
@@ -15,39 +15,50 @@ source:
 build:
   number: 0
   skip: true  # [win and vc<14]
-  skip: True  # [win32]
   run_exports:
     - {{ pin_subpackage("lcms2") }}
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - make  # [not win]
+    - make     # [not win]
     - libtool  # [unix]
   host:
-    - jpeg
-    - libtiff
+    - jpeg {{ jpeg }}
+    - libtiff 4.5.1
 
 test:
   commands:
-    - test -f ${PREFIX}/include/lcms2.h  # [not win]
-    - test -f ${PREFIX}/lib/liblcms2.a  # [not win]
-    - test -f ${PREFIX}/lib/liblcms2${SHLIB_EXT}  # [not win]
     - jpgicc
     - tificc
     - linkicc
     - transicc
     - psicc
+    - test -f ${PREFIX}/include/lcms2.h  # [not win]
+    - test -f ${PREFIX}/include/lcms2_plugin.h  # [not win]
+    - test ! -f ${PREFIX}/lib/liblcms2.a  # [not win]
+    - test -f ${PREFIX}/lib/liblcms2${SHLIB_EXT}  # [not win]
+    - test -f ${PREFIX}/lib/pkgconfig/lcms2.pc  # [not win]
+    - if not exist %LIBRARY_INC%\\lcms2_plugin.h exit 1  # [win]
     - if not exist %LIBRARY_INC%\\lcms2.h exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\lcms2.lib exit 1  # [win]
     - if not exist %LIBRARY_BIN%\\lcms2.dll exit 1  # [win]
 
 about:
   home: http://www.littlecms.com/
+  dev_url: https://github.com/mm2/Little-CMS
+  doc_url: https://github.com/mm2/Little-CMS/tree/master/doc
   license: MIT
   license_family: MIT
-  license_file: COPYING
+  license_file: LICENSE
   summary: Open Source Color Management Engine
+  description: |
+    Little CMS intends to be an OPEN SOURCE small-footprint color management engine,
+    with special focus on accuracy and performance.
+    It uses the International Color Consortium standard (ICC),
+    which is the modern standard when regarding to color management.
+    The ICC specification is widely used and is referred to in many International
+    and other de-facto standards. It was approved as an International Standard, ISO 15076-1, in 2005.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,9 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - make     # [not win]
-    - libtool  # [unix]
+    - make      # [not win]
+    - libtool   # [unix]
+    - m2-patch  # [win]
   host:
     - jpeg {{ jpeg }}
     # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
@@ -47,7 +48,7 @@ test:
     - if not exist %LIBRARY_BIN%\\lcms2.dll exit 1  # [win]
 
 about:
-  home: http://www.littlecms.com/
+  home: https://www.littlecms.com/
   dev_url: https://github.com/mm2/Little-CMS
   doc_url: https://github.com/mm2/Little-CMS/tree/master/doc
   license: MIT


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6505](https://anaconda.atlassian.net/browse/PKG-6505) 
- [Upstream repository](https://github.com/mm2/Little-CMS/tree/lcms2.16)
- Requirements:
  - https://github.com/mm2/Little-CMS/blob/lcms2.16/doc/LittleCMS2.16%20API.pdf

### Explanation of changes:

- Pin libtiff to 4.5.1
- Use vs2019 on win
- Add --disable-static on unix
- Add more test commands
- Add dev& doc urls
- Update license name
- Add description

### Notes:

- https://github.com/AnacondaRecipes/libtiff-feedstock/pull/20

[PKG-6505]: https://anaconda.atlassian.net/browse/PKG-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ