### PR TITLE
lcms2 2.16: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - patch     # [not win]
   host:
     - jpeg {{ jpeg }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [s390x or (win and vc<14)]
+  skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("lcms2") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0003_fix_a_bug_in_planar_half16_formatter.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("lcms2") }}
@@ -28,7 +28,7 @@ requirements:
     - patch     # [not win]
   host:
     - jpeg {{ jpeg }}
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [win and vc<14]
+  skip: true  # [s390x or (win and vc<14)]
   run_exports:
     - {{ pin_subpackage("lcms2") }}
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7588](https://anaconda.atlassian.net/browse/PKG-7588) 
- [Upstream repository](https://github.com/mm2/Little-CMS/tree/lcms2.16)

### Explanation of changes:

- Bump the build number to 1
- Pin libtiff in host

### Notes:

-

[PKG-7588]: https://anaconda.atlassian.net/browse/PKG-7588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ