### PR TITLE
Update version to 2.19.1, change jpeg to libjpeg-turbo

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
 set UseEnv=true
 
+copy %LIBRARY_LIB%\jpeg.lib %LIBRARY_LIB%\libjpeg.lib
 REM VC2019 vcxproj files pin PlatformToolset=v142, but the CI image only has
 REM the VS 2022 v143/v144 toolsets. Override here so msbuild uses what is
 REM actually installed (avoids MSB8052 without patching the .sln/.vcxproj).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lcms2" %}
-{% set version = "2.19" %}
+{% set version = "2.19.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/mm2/Little-CMS/releases/download/lcms{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216
+  sha256: bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8
 
 build:
   number: 0
@@ -21,7 +21,7 @@ requirements:
     - make      # [not win]
     - libtool   # [unix]
   host:
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libtiff {{ libtiff }}
 
 test:


### PR DESCRIPTION
lcms2 2.19.1

**Destination channel:** defaults

### Links

- [PKG-13227](https://anaconda.atlassian.net/browse/PKG-13227) 
- [Upstream repository](https://github.com/mm2/Little-CMS/tree/lcms2.19.1)

### Explanation of changes:
- Update version to 2.19.1
- Change jpeg to libjpeg-turbo


[PKG-13227]: https://anaconda.atlassian.net/browse/PKG-13227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ